### PR TITLE
Keep the same id in SCTE-OUT/IN pairs inside EXT-X-DATERANGE, as specified in the hls standard

### DIFF
--- a/x9k3.py
+++ b/x9k3.py
@@ -484,7 +484,6 @@ class SCTE35:
         if self.cue_state == "OUT":
             fstart = f',START-DATE="{iso8601}"'
             tag = f"{fbase}{fstart}{fdur},SCTE35-OUT={self.cue.encode_as_hex()}"
-            self.event_id += 1
             return tag
 
         if self.cue_state == "IN":


### PR DESCRIPTION
https://github.com/futzu/x9k3/issues/19

The hls standard states that:

>An SCTE-35 splice out/in pair signaled by a pair of splice_insert()
    commands SHOULD be represented by one or more EXT-X-DATERANGE tags
    carrying the same ID attribute, which MUST be unique to that splice
    out/in pair.

https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.5.1.1

This tool generates that pair with different ids for each scte command.